### PR TITLE
Micropython docs

### DIFF
--- a/micropython.md
+++ b/micropython.md
@@ -14,7 +14,7 @@
 
 Download and install Python from the [official website](https://www.python.org/downloads/). During installation, ensure you select the option to add Python to your PATH.
 
-### **Linux: Debian based**
+#### **Linux: Debian based**
 
 Most Debian-based systems come with Python pre-installed. Verify by running:
 
@@ -29,7 +29,7 @@ sudo apt-get update
 sudo apt-get install python3 python3-pip
 ```
 
-### **Linux: Fedora**
+#### **Linux: Fedora**
 
 Fedora normally comes with Python pre-installed, to verify this, run:
 
@@ -100,7 +100,7 @@ Activate the virtual environment:
 source micropython-env/bin/activate
 ```
 
-### **Linux: Fedora**
+#### **Linux: Fedora**
 
 In Fedora, Python 3 includes the built-in venv module.
 

--- a/micropython.md
+++ b/micropython.md
@@ -342,7 +342,7 @@ sudo dnf install thonny
 
 3. **Upload all files to Walter**:
 
-   - Upload the `boot.py`, `queue.py`, `walter.py` and `_walter.py` file by right clicking on each file and selecting `Upload to /`.  Now, the library is uploaded to Walter and the uploaded `boot.py` script will run on every restart.
+   - Upload the `boot.py`, `queue.py`, `walter.py` and `_walter.py` file by right clicking on each file and selecting `Upload to /`, if this option is not availble, click on: `File` -> `Save as...`, and select `MicroPython device`.  Now, the library is uploaded to Walter and the uploaded `boot.py` script will run on every restart.
 
 You can find some example applications for Walter in the `examples` folder.
 

--- a/micropython.md
+++ b/micropython.md
@@ -125,21 +125,36 @@ pip install esptool
 
 ## Step 2: Download MicroPython firmware
 
-1. **Download the MicroPython firmware**: Visit the [MicroPython ESP32-S3 download page](https://micropython.org/download/ESP32_GENERIC_S3/) and download the latest stable **.bin** firmware release for the ESP32-S3.
+### Download the MicroPython firmware
 
-2. **Identify the correct COM port**:
-   
-   - **Windows**: Connect your Walter to your computer via USB. Identify the COM port by opening Device Manager and checking under "Ports (COM & LPT)". The port will be labeled something like `COM3` or `COM4`.
-   
-   - **Debian-based OS**: Connect your ESP32-S3 to your computer via USB and identify the port by running:
-     
-     ```shell
-     ls /dev/ttyACM*
-     ```
-     
-     The port will look something like `/dev/ttyACM0`.
-   
-   - Remember the port for the following steps.
+Visit the [MicroPython ESP32-S3 download page](https://micropython.org/download/ESP32_GENERIC_S3/) and download the latest stable **.bin** firmware release for the ESP32-S3.
+
+### Identify the correct COM port
+
+<!-- tabs:start -->
+
+#### **Windows**
+
+Connect your Walter to your computer via USB. Identify the COM port by opening Device Manager and checking under "Ports (COM & LPT)". The port will be labeled something like `COM3` or `COM4`.
+
+#### **Linux: Debian-based**
+
+Connect your ESP32-S3 to your computer via USB and identify the port by running:
+
+```shell
+ls /dev/ttyACM*
+```
+
+#### **Linux: Fedora**
+
+Connect your ESP32-S3 to your computer via USB and identify the port by running:
+
+```shell
+ls /dev/ttyACM*
+```
+<!-- tabs:end -->
+
+The port will look something like `/dev/ttyACM0`, remember the port for the following steps.
 
 ## Step 3: Flash MicroPython onto the ESP32-S3
 

--- a/micropython.md
+++ b/micropython.md
@@ -290,48 +290,58 @@ You can write and test simple scripts directly in the REPL, such as the followin
 
 Uploading files to a Walter running MicroPython lets you deploy full scripts that are saved to the device’s filesystem, making them persistent and ready to run even after a reboot. Several tools are available, such as [Thonny](https://thonny.org/), [ampy](https://github.com/scientifichackers/ampy) and [rshell](https://github.com/dhylands/rshell). Thonny is an integrated development environment (IDE) designed for Python. It also supports MicroPython, making it a popular choice for uploading scripts to a MicroPython device.
 
-1. **Install Thonny**:
-   
-   - **Windows**: Download and install Thonny from the [official website](https://thonny.org/).
-   
-   - **Debian-based OS**: Install Thonny using the following command:
-     
-     ```shell
-     sudo apt-get install thonny
-     ```
+### Install Thonny
 
-2. **Connect Thonny to ESP32-S3**:
-   
-   - Open Thonny and go to `Tools` > `Options` > `Interpreter`.
-   
-   - Set the interpreter to `MicroPython (ESP32)`.
-   
-   - Set the port to `< Try to detect port automatically >`.
+<!-- tabs:start -->
 
-3. **Write and upload scripts**:
-   
-   - Write your MicroPython script in the editor.
-   
-   - Click the `Run current script` button to run the script on Walter.
+#### **Windows**
+
+Download and install Thonny from the [official website](https://thonny.org/).
+
+#### **Linux: Debian-based**
+
+Install Thonny using the following command:
+
+```shell
+sudo apt-get install thonny
+```
+
+#### **Linux: Fedora**
+
+Install Thonny using the following command:
+
+```shell
+sudo dnf install thonny
+```
+<!-- tabs:end -->
+
+### Connect Thonny to ESP32-S3
+
+- Open Thonny and go to `Tools` > `Options` > `Interpreter`.
+- Set the interpreter to `MicroPython (ESP32)`.
+- Set the port to `< Try to detect port automatically >`.
+
+### Write and upload scripts
+
+- Write your MicroPython script in the editor.
+- Click the `Run current script` button to run the script on Walter.
 
 ## Step 7: Using the Walter MicroPython library
 
 1. **Clone the Walter MicroPython library**:
-   
+
    ```shell
    git clone https://github.com/QuickSpot/walter-micropython.git
    ```
 
 2. **Open the repository in Thonny**:
-   
+
    - Open Thonny and ensure that the MicroPython interpreter is set up correctly (as done in Step 6).
-   
    - Go to `File` -> `Open...`.
-   
    - Navigate to the local directory where you cloned the repository.
 
 3. **Upload all files to Walter**:
-   
+
    - Upload the `boot.py`, `queue.py`, `walter.py` and `_walter.py` file by right clicking on each file and selecting `Upload to /`.  Now, the library is uploaded to Walter and the uploaded `boot.py` script will run on every restart.
 
 You can find some example applications for Walter in the `examples` folder.

--- a/micropython.md
+++ b/micropython.md
@@ -158,11 +158,11 @@ The port will look something like `/dev/ttyACM0`, remember the port for the foll
 
 ## Step 3: Flash MicroPython onto the ESP32-S3
 
-### Erase the flash
-
 <!-- tabs:start -->
 
-#### **Windows**
+### **Windows**
+
+#### Erase the flash
 
 Run the following command, replacing `<your_port>` with your identifed port from the previous step:
 
@@ -170,29 +170,7 @@ Run the following command, replacing `<your_port>` with your identifed port from
 esptool --chip esp32s3 --port <your_port> erase_flash
 ```
 
-#### **Linux: Debian-based**
-
-Run the following command, replacing `<your_port>` with your identifed port from the previous step:
-
-```shell
-esptool.py --chip esp32s3 --port <your_port> erase_flash
-```
-
-#### **Linux: Fedora**
-
-Run the following command, replacing `<your_port>` with your identifed port from the previous step:
-
-```shell
-esptool.py --chip esp32s3 --port <your_port> erase_flash
-```
-
-<!-- tabs:end -->
-
-### Flash the firmware
-
-<!-- tabs:start -->
-
-#### **Windows**
+#### Flash the firmware
 
 Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
   
@@ -200,7 +178,17 @@ Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_
 esptool --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
 ```
 
-#### **Linux: Debian-based**
+### **Linux: Debian-based**
+
+#### Erase the flash
+
+Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> erase_flash
+```
+
+#### Flash the firmware
 
 Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
 
@@ -208,13 +196,24 @@ Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_
 esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
 ```
 
-#### **Linux: Fedora**
+### **Linux: Fedora**
+
+#### Erase the flash
+
+Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> erase_flash
+```
+
+#### Flash the firmware
 
 Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
 
 ```shell
 esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
 ```
+
 <!-- tabs:end -->
 
 ## Step 4: Access the MicroPython REPL

--- a/micropython.md
+++ b/micropython.md
@@ -51,7 +51,7 @@ sudo dnf install python3 python3-pip
 
 #### **Windows**
 
-1. Open a terminal window in your project directory.
+Open a terminal window in your project directory.
 
 - *Open "Terminal" and navigate to the project directory `cd path/to/your/project/dir`*
 - *Alternatively, navigate to your project directory in File Explorer, then right-click in the empty space and select "Open in Terminal."*
@@ -162,57 +162,45 @@ The port will look something like `/dev/ttyACM0`, remember the port for the foll
 
 ### **Windows**
 
-#### Erase the flash
+1. **Erase the flash** Run the following command, replacing `<your_port>` with your identifed port from the previous step:
 
-Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+   ```shell
+   esptool --chip esp32s3 --port <your_port> erase_flash
+   ```
 
-```shell
-esptool --chip esp32s3 --port <your_port> erase_flash
-```
-
-#### Flash the firmware
-
-Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
+2. **Flash the firmware** Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
   
-```shell
-esptool --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
-```
+   ```shell
+   esptool --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+   ```
 
 ### **Linux: Debian-based**
 
-#### Erase the flash
+1. **Erase the flash** Run the following command, replacing `<your_port>` with your identifed port from the previous step:
 
-Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+   ```shell
+   esptool.py --chip esp32s3 --port <your_port> erase_flash
+   ```
 
-```shell
-esptool.py --chip esp32s3 --port <your_port> erase_flash
-```
+2. **Flash the firmware** Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
 
-#### Flash the firmware
-
-Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
-
-```shell
-esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
-```
+   ```shell
+   esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+   ```
 
 ### **Linux: Fedora**
 
-#### Erase the flash
+1. **Erase the flash** Run the following command, replacing `<your_port>` with your identifed port from the previous step:
 
-Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+   ```shell
+   esptool.py --chip esp32s3 --port <your_port> erase_flash
+   ```
 
-```shell
-esptool.py --chip esp32s3 --port <your_port> erase_flash
-```
+2. **Flash the firmware** Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
 
-#### Flash the firmware
-
-Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
-
-```shell
-esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
-```
+   ```shell
+   esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+   ```
 
 <!-- tabs:end -->
 
@@ -220,52 +208,73 @@ esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
 
 The REPL (Read-Eval-Print Loop) is an interactive prompt that allows you to run Python commands directly on the ESP32-S3.
 
-### Windows
+<!-- tabs:start -->
+
+### **Windows**
 
 1. **Install PuTTY**: Download and install PuTTY from the [official website](https://www.putty.org/).
 
 2. **Open PuTTY**:
-   
    - Set the connection type to `Serial`.
-   
    - Enter your COM port (e.g., `COM3`) and set the speed to `115200`.
-   
    - Click "Open" to start the session.
 
 3. **Access the REPL**: Press the `Enter` key. You should see the MicroPython prompt (`>>>`). Try typing the following in the prompt:
-   
+
    ```python
    >>> print('Hello Walter!')
    Hello Walter!
    ```
 
-### Debian-based OS
+### **Linux: Debian-based**
 
 1. **Install picocom**: If you don't have picocom installed, install it using:
-   
+
    ```shell
    sudo apt-get install picocom
    ```
 
 2. **Open a serial terminal**: Open picocom with the following command:
-   
+
    ```shell
    picocom -b 115200 <your_port>
    ```
 
 3. **Access the REPL**: Press the `Enter` key. You should see the MicroPython prompt (`>>>`). Try typing the following in the prompt:
-   
+
    ```python
    >>> print('Hello Walter!')
    Hello Walter!
    ```
+
+### **Linux: Fedora**
+
+1. **Install picocom**: If you don't have picocom installed, install it using:
+
+   ```shell
+   sudo dnf install picocom
+   ```
+
+2. **Open a serial terminal**: Open picocom with the following command:
+
+   ```shell
+   picocom -b 115200 <your_port>
+   ```
+
+3. **Access the REPL**: Press the `Enter` key. You should see the MicroPython prompt (`>>>`). Try typing the following in the prompt:
+
+   ```python
+   >>> print('Hello Walter!')
+   Hello Walter!
+   ```
+<!-- tabs:end -->
 
 ## Step 5: Writing and running your first MicroPython script
 
 You can write and test simple scripts directly in the REPL, such as the following Hello World example:
 
 1. **Hello World**: This simple script will print `Hello World` followed by a random int between 0 and 10 every second. Enter the following code in the REPL:
-   
+
    ```python
    from time import sleep
    from random import randint

--- a/micropython.md
+++ b/micropython.md
@@ -158,23 +158,64 @@ The port will look something like `/dev/ttyACM0`, remember the port for the foll
 
 ## Step 3: Flash MicroPython onto the ESP32-S3
 
-> When using a Debian-based OS for the following steps, replace `esptool` with `esptool.py`.
+### Erase the flash
 
-1. **Erase the flash**:
-   
-   - Run the following command, replacing `<your_port>` with your identifed port from the previous step:
-     
-     ```shell
-     esptool --chip esp32s3 --port <your_port> erase_flash
-     ```
+<!-- tabs:start -->
 
-2. **Flash the firmware**:
-   
-   - Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
-     
-     ```shell
-     esptool --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
-     ```
+#### **Windows**
+
+Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+
+```shell
+esptool --chip esp32s3 --port <your_port> erase_flash
+```
+
+#### **Linux: Debian-based**
+
+Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> erase_flash
+```
+
+#### **Linux: Fedora**
+
+Run the following command, replacing `<your_port>` with your identifed port from the previous step:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> erase_flash
+```
+
+<!-- tabs:end -->
+
+### Flash the firmware
+
+<!-- tabs:start -->
+
+#### **Windows**
+
+Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
+  
+```shell
+esptool --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+```
+
+#### **Linux: Debian-based**
+
+Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+```
+
+#### **Linux: Fedora**
+
+Use esptool to flash the MicroPython firmware onto the ESP32-S3. Replace `<your_port>` and `<firmware_path>` with your port and the path to the downloaded firmware:
+
+```shell
+esptool.py --chip esp32s3 --port <your_port> write_flash -z 0 <firmware_path>
+```
+<!-- tabs:end -->
 
 ## Step 4: Access the MicroPython REPL
 

--- a/micropython.md
+++ b/micropython.md
@@ -14,7 +14,7 @@
 
 Download and install Python from the [official website](https://www.python.org/downloads/). During installation, ensure you select the option to add Python to your PATH.
 
-#### **Linux: Debian based**
+#### **Linux: Debian-based**
 
 Most Debian-based systems come with Python pre-installed. Verify by running:
 
@@ -80,7 +80,7 @@ micropython-env\Scripts\activate
 > .\micropython-env\Scripts\Activate.ps1
 > ```
 
-#### **Linux: Debian based**
+#### **Linux: Debian-based**
 
 Install the `venv` module if it's not already installed:
 

--- a/micropython.md
+++ b/micropython.md
@@ -6,76 +6,127 @@
 
 ## Step 1: Install Python and required tools
 
-### Windows
+### Python
 
-1. **Install Python**: Download and install Python from the [official website](https://www.python.org/downloads/). During installation, ensure you select the option to add Python to your PATH.
+<!-- tabs:start -->
 
-2. **Set up a Python virtual environment**:
-   
-   - Open Terminal and navigate to your project directory.
-   
-   - Create a virtual environment:
-     
-     ```shell
-     python -m venv micropython-env
-     ```
-   
-   - Activate the virtual environment:
-     
-     ```shell
-     micropython-env\Scripts\activate
-     ```
-   
-   - Your terminal prompt should change to indicate that the virtual environment is active.
+#### **Windows**
 
-3. **Install esptool**: [esptool](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/index.html) is a Python-based tool that helps you flash the MicroPython firmware onto the ESP32-S3 SoC of your Walter board. Within the virtual environment, install esptool using pip:
-   
-   ```shell
-   pip install esptool
-   ```
+Download and install Python from the [official website](https://www.python.org/downloads/). During installation, ensure you select the option to add Python to your PATH.
 
-### Debian-based OS
+### **Linux: Debian based**
 
-1. **Install Python**: Most Debian-based systems come with Python pre-installed. Verify by running:
-   
-   ```shell
-   python3 --version
-   ```
-   
-   If not installed, install it with:
-   
-   ```shell
-   sudo apt-get update
-   sudo apt-get install python3 python3-pip
-   ```
+Most Debian-based systems come with Python pre-installed. Verify by running:
 
-2. **Set up a Python virtual environment**:
-   
-   - Install the `venv` module if it's not already installed:
-     
-     ```shell
-     sudo apt-get install python3-venv
-     ```
-   
-   - Create a virtual environment inside your project directory:
-     
-     ```shell
-     python3 -m venv micropython-env
-     ```
-   
-   - Activate the virtual environment:
-     
-     ```shell
-     source micropython-env/bin/activate
-     ```
-   
-   - Your terminal prompt should change to indicate that the virtual environment is active.
+```shell
+python3 --version
+```
 
-3. **Install esptool**: [esptool](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/index.html) is a Python-based tool that helps you flash the MicroPython firmware onto the ESP32-S3 SoC of your Walter board. Within the virtual environment, install esptool using pip:
-   
-   ```shell
-   pip install esptool
-   ```
+If not installed, install it with:
+
+```shell
+sudo apt-get update
+sudo apt-get install python3 python3-pip
+```
+
+### **Linux: Fedora**
+
+Fedora normally comes with Python pre-installed, to verify this, run:
+
+```shell
+python3 --version
+```
+
+If Python is not installed on your system, you can install it like so:
+
+```shell
+sudo dnf install python3 python3-pip
+```
+
+<!-- tabs:end -->
+
+### Python virtual environment
+
+<!-- tabs:start -->
+
+#### **Windows**
+
+Open a terminal window in your project directory.
+
+- Open Terminal and navigate to the project directory with:
+
+```shell
+cd path/to/your/project/dir
+```
+
+Alternatively, navigate to your project directory in File Explorer, then right-click in the empty space and select "Open in Terminal."
+
+Create a virtual environment:
+
+```shell
+python -m venv micropython-env
+```
+
+Activate the virtual environment:
+
+```shell
+micropython-env\Scripts\activate
+```
+
+> **NOTE**\
+> In PowerShell, the activation command would be:
+>
+> ```ps
+> .\micropython-env\Scripts\Activate.ps1
+> ```
+
+#### **Linux: Debian based**
+
+Install the `venv` module if it's not already installed:
+
+```shell
+sudo apt-get install python3-venv
+```
+
+Create a virtual environment inside your project directory:
+
+```shell
+python3 -m venv micropython-env
+```
+
+Activate the virtual environment:
+
+```shell
+source micropython-env/bin/activate
+```
+
+### **Linux: Fedora**
+
+In Fedora, Python 3 includes the built-in venv module.
+
+Create a virtual environment inside your project directory:
+
+```shell
+python3 -m venv micropython-env
+```
+
+Activate the virtual environment:
+
+```shell
+source micropython-env/bin/activate
+```
+
+<!-- tabs:end -->
+
+*Your terminal prompt should change to indicate that the virtual environment is active.*
+
+### ESPTool
+
+[esptool](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/index.html) is a Python-based tool that helps you flash the MicroPython firmware onto the ESP32-S3 SoC of your Walter board. Within the virtual environment, install esptool using pip:
+
+```shell
+pip install esptool
+```
 
 ## Step 2: Download MicroPython firmware
 

--- a/micropython.md
+++ b/micropython.md
@@ -51,15 +51,10 @@ sudo dnf install python3 python3-pip
 
 #### **Windows**
 
-Open a terminal window in your project directory.
+1. Open a terminal window in your project directory.
 
-- Open Terminal and navigate to the project directory with:
-
-```shell
-cd path/to/your/project/dir
-```
-
-Alternatively, navigate to your project directory in File Explorer, then right-click in the empty space and select "Open in Terminal."
+- *Open "Terminal" and navigate to the project directory `cd path/to/your/project/dir`*
+- *Alternatively, navigate to your project directory in File Explorer, then right-click in the empty space and select "Open in Terminal."*
 
 Create a virtual environment:
 


### PR DESCRIPTION
Updated micropython.md to organise different OS's in tabs & added Linux: fedora

For the tabs to properly work, the docsify-tabs plugin must be added to the html.
See the [docisfy-tabs documentation](https://jhildenbiddle.github.io/docsify-tabs/#/?id=installation) for further information.

![image](https://github.com/user-attachments/assets/8dbfac36-cba1-4c4c-ac09-870d71fa6dd0)
*Screenshot of local setup of docsify, used to test*
