### PR TITLE
Fix typos in python sections

### DIFF
--- a/walter-modem/common.md
+++ b/walter-modem/common.md
@@ -128,7 +128,7 @@ Retrieves the current time and date from the modem.
 ```py
 modem_rsp = ModemRsp()
 
-if await modem.get_clock(rps=modem_rsp):
+if await modem.get_clock(rsp=modem_rsp):
     print(modem_rsp.clock)
 else:
     print('Failed to get modem clock')
@@ -275,7 +275,7 @@ Retrieves the modem's current operational state.
 ```py
 modem_rsp = ModemRsp()
 
-if await modem.get_op_state(rps=modem_rsp):
+if await modem.get_op_state(rsp=modem_rsp):
     print(WalterModemOpState.get_value_name(modem_rsp.op_state))
 else:
     print('Failed to get modem op state')

--- a/walter-modem/http.md
+++ b/walter-modem/http.md
@@ -84,7 +84,7 @@ TLS_PROFILE = 1
 
 if await modem.http_config_profile(
     profile_id=HTTP_PROFILE,
-    server_address="tls13.akamai.io,
+    server_address="tls13.akamai.io",
     port=443,
     tls_profile_id=TLS_PROFILE
 ):

--- a/walter-modem/http.md
+++ b/walter-modem/http.md
@@ -454,11 +454,14 @@ while(modem.httpDidRing(HTTP_PROFILE, incomingBuf, sizeof(incomingBuf), &rsp)) {
 
 ```py
 modem_rsp = ModemRsp()
-http_receive_attempts_left = 0
 
-while await modem.http_did_ring(profile_id=http_profile, rsp=modem_rsp):
-    http_receive_attempts_left = 0
+while not await modem.http_did_ring(profile_id=HTTP_PROFILE, rsp=modem_rsp):
+    if modem_rsp.result not in (WalterModemState.OK, WalterModemState.AWAITING_RING):
+        print(f"Error: {modem_rsp.result}")
+        break
+    await asyncio.sleep(1)
 
+if modem_rsp.http_response is not None
     print(f'HTTP status code: {modem_rsp.http_response.http_status}')
     print(f'HTTP content type: {modem_rsp.http_response.content_type}')
     print(f'HTTP: {modem_rsp.http_response.data}')

--- a/walter-modem/setup/micropython.md
+++ b/walter-modem/setup/micropython.md
@@ -155,7 +155,7 @@ from walter_modem.structs import (
   # ...
 )
 
-modem = walter.Modem()
+modem = Modem()
 
 async def main():
     # ...


### PR DESCRIPTION
Add missing `"`, fix typo for module and fix the argument name in some examples.

Also updated the httpDidRing() example after some guidance from @FoxyHunter7 earlier today